### PR TITLE
Update find-button logic to filter rows with empty start and end times

### DIFF
--- a/src/content.ts
+++ b/src/content.ts
@@ -35,11 +35,19 @@ const findTargets = () => {
     }
 
     const tr = cell.closest("tr")!;
-    const options = tr.firstElementChild?.querySelectorAll("option")!;
-    const buttonId = Array.from(options).find((option) => option.text === "打刻編集")!.value;
-    const date = tr.querySelector<HTMLTableCellElement>("td:nth-child(2)")!.innerText;
+    const startTd = tr.querySelector<HTMLTableCellElement>("td.start_end_timerecord[data-ht-sort-index='START_TIMERECORD']"); // 出勤列
+    const endTd = tr.querySelector<HTMLTableCellElement>("td.start_end_timerecord[data-ht-sort-index='END_TIMERECORD']");   // 退勤列
 
-    targets.push({ date, buttonId });
+    if (
+      startTd?.innerText.trim() === "" &&
+      endTd?.innerText.trim() === ""
+    ) {
+      const options = tr.firstElementChild?.querySelectorAll("option")!;
+      const buttonId = Array.from(options).find((option) => option.text === "打刻編集")!.value;
+      const date = tr.querySelector<HTMLTableCellElement>("td:nth-child(2)")!.innerText;
+
+      targets.push({ date, buttonId });
+    }
   }
   console.log("targets", targets);
   return targets;

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -35,7 +35,21 @@ document.getElementById("find-button")?.addEventListener("click", () => {
 document.getElementById("start-button")?.addEventListener("click", () => {
 	console.log("start-button clicked");
 
-	execute(data.targets, data.timestamps);
+	// 今日までの日付を対象とするロジック
+	const today = new Date(); // 現在の日付を動的に取得
+	const filteredTargets = data.targets.filter(({ date }) => {
+		// dateを正しくパース
+		const [month, day] = date.match(/\d+/g)!.map(Number);
+		const targetDate = new Date(today.getFullYear(), month - 1, day); // 年は現在の年を使用
+		return targetDate <= today; // 今日までの日付を対象にする
+	});
+
+	if (filteredTargets.length === 0) {
+		alert("登録可能な日付がありません。");
+		return;
+	}
+
+	execute(filteredTargets, data.timestamps);
 });
 
 const send = <T>(action: string, callback: (response: T) => void) => {


### PR DESCRIPTION
This PR updates the logic for the find-button to filter rows where both the start and end time columns are empty. It ensures that only relevant rows are processed.\n\nCloses #1